### PR TITLE
feat: demo multi-containers in one github action

### DIFF
--- a/.github/workflows/18_multi_container.yml
+++ b/.github/workflows/18_multi_container.yml
@@ -1,0 +1,22 @@
+name: Multiple Containers
+on: push
+
+# runs a simple nodejs api server which connects to a local mongo database
+jobs:
+  similar-to-docker-compose:
+    runs-on: ubuntu-latest
+    # runs multiple containers using a yaml syntax similiar to docker-compose
+    services:
+      app:
+        image: alialaa17/node-api
+        ports:
+          - 3001:3000
+      mongo:
+        image: mongo
+        ports:
+          - "27017:27017"
+    steps:
+      - name: Post a user
+        run: 'curl -X POST http://localhost:3001/api/user -H ''Content-Type: application/json'' -d ''{"username": "hello","address": "dwded"}'''
+      - name: Get Users
+        run: curl http://localhost:3001/api/users


### PR DESCRIPTION
With github actions you can run multiple containers using yaml syntax similar to docker-compose. This example shows a simple nodejs api running in one container with a mongo backend running in another container.